### PR TITLE
Changed project "SKIP_INSTALL" property to YES, to allow generate IPA package instead of Generic Xcode Archives

### DIFF
--- a/CBForest.xcodeproj/project.pbxproj
+++ b/CBForest.xcodeproj/project.pbxproj
@@ -2008,6 +2008,7 @@
 					"-DHAVE_GCC_ATOMICS=1",
 				);
 				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
 				WARNING_CFLAGS = (
 					"-Wall",
 					"-Wformat-security",
@@ -2065,6 +2066,7 @@
 					"-DNDEBUG",
 				);
 				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
 				WARNING_CFLAGS = (
 					"-Wall",
 					"-Wformat-security",


### PR DESCRIPTION
When one of embedded subprojects have this property value, set to NO, parent project will generate generic xcode archive instead of IPA
Fix according to these answer
http://stackoverflow.com/questions/10715211/cannot-generate-ios-app-archive-in-xcode