### PR TITLE
Update JNI bindings to catchup recent C-API updates and Added helper methods

### DIFF
--- a/Java/jni/native_database.cc
+++ b/Java/jni/native_database.cc
@@ -57,6 +57,19 @@ jlong JNICALL Java_com_couchbase_cbforest_Database__1open
     return (jlong)db;
 }
 
+JNIEXPORT void JNICALL Java_com_couchbase_cbforest_Database_rekey
+(JNIEnv *env, jobject self, jint encryptionAlg, jbyteArray encryptionKey){
+    C4EncryptionKey key;
+    if (!getEncryptionKey(env, encryptionAlg, encryptionKey, &key))
+        return;
+
+    auto db = getDbHandle(env, self);
+    if (db) {
+        C4Error error;
+        if(!c4db_rekey(db, &key, &error))
+            throwError(env, error);
+    }
+}
 
 JNIEXPORT void JNICALL Java_com_couchbase_cbforest_Database_free
 (JNIEnv *env, jobject self)
@@ -70,6 +83,16 @@ JNIEXPORT void JNICALL Java_com_couchbase_cbforest_Database_free
     }
 }
 
+JNIEXPORT void JNICALL Java_com_couchbase_cbforest_Database_compact
+(JNIEnv *env, jobject self)
+{
+    auto db = getDbHandle(env, self);
+    if (db) {
+        C4Error error;
+        if (!c4db_compact(db, &error))
+            throwError(env, error);
+    }
+}
 
 JNIEXPORT jlong JNICALL Java_com_couchbase_cbforest_Database_getDocumentCount
 (JNIEnv *env, jobject self)

--- a/Java/src/com/couchbase/cbforest/Constants.java
+++ b/Java/src/com/couchbase/cbforest/Constants.java
@@ -3,7 +3,7 @@ package com.couchbase.cbforest;
 /**
  * Created by hideki on 9/30/15.
  */
-interface Constants {
+public interface Constants {
 
     // fdb_errors.h
     interface FDBErrors {
@@ -191,6 +191,8 @@ interface Constants {
          */
         int FDB_RESULT_CRYPTO_ERROR = -44;
     }
+
+    //////// DOCUMENTS:
 
     // Flags describing a document.
     // Note: Superset of VersionedDocument::Flags

--- a/Java/src/com/couchbase/cbforest/Constants.java
+++ b/Java/src/com/couchbase/cbforest/Constants.java
@@ -186,6 +186,10 @@ interface Constants {
          * Fail to read asynchronous I/O events from the completion queue.
          */
         int FDB_RESULT_AIO_GETEVENTS_FAIL = -43;
+        /**
+         * Error encrypting or decrypting data, or unsupported encryption algorithm.
+         */
+        int FDB_RESULT_CRYPTO_ERROR = -44;
     }
 
     // Flags describing a document.

--- a/Java/src/com/couchbase/cbforest/Database.java
+++ b/Java/src/com/couchbase/cbforest/Database.java
@@ -40,6 +40,18 @@ public class Database {
         return new Document(_handle, sequence);
     }
 
+    public DocumentIterator iterator() throws ForestException {
+        return new DocumentIterator(_handle);
+    }
+
+    public DocumentIterator iterator(String startDocID, String endDocID) throws ForestException {
+        return new DocumentIterator(_handle, startDocID, endDocID);
+    }
+
+    public DocumentIterator iterator(long sinceSequence) throws ForestException {
+        return new DocumentIterator(_handle, sinceSequence);
+    }
+
     public DocumentIterator iterateChanges(long sinceSequence, boolean withBodies) throws ForestException {
         return new DocumentIterator(_iterateChanges(sinceSequence, withBodies));
     }

--- a/Java/src/com/couchbase/cbforest/Database.java
+++ b/Java/src/com/couchbase/cbforest/Database.java
@@ -16,7 +16,11 @@ public class Database {
         _handle = _open(path, flags, encryptionAlgorithm, encryptionKey);
     }
 
+    public native void rekey(int encryptionAlgorithm, byte[] encryptionKey) throws ForestException;
+
     public native void free();
+
+    public native void compact() throws ForestException;
 
     public native long getDocumentCount();
 
@@ -30,6 +34,10 @@ public class Database {
 
     public Document getDocument(String docID, boolean mustExist) throws ForestException {
         return new Document(_handle, docID, mustExist);
+    }
+
+    public Document getDocumentBySequence(long sequence) throws ForestException {
+        return new Document(_handle, sequence);
     }
 
     public DocumentIterator iterateChanges(long sinceSequence, boolean withBodies) throws ForestException {

--- a/Java/src/com/couchbase/cbforest/Document.java
+++ b/Java/src/com/couchbase/cbforest/Document.java
@@ -1,6 +1,6 @@
 package com.couchbase.cbforest;
 
-public class Document {
+public class Document implements Constants{
 
     public String getDocID()        { return _docID; }
 
@@ -102,4 +102,38 @@ public class Document {
     private int _selectedRevFlags;
     private long _selectedSequence;
     private byte[] _selectedBody;
+
+    // helper methods for Document
+    public boolean deleted(){
+        return isFlags(C4DocumentFlags.kDeleted);
+    }
+    public boolean conflicted(){
+        return isFlags(C4DocumentFlags.kConflicted);
+    }
+    public boolean hasAttachments(){
+        return isFlags(C4DocumentFlags.kHasAttachments);
+    }
+    public boolean exists(){
+        return isFlags(C4DocumentFlags.kExists);
+    }
+    private boolean isFlags(int flag){
+        return (_flags & flag) == flag;
+    }
+
+    // helper methods for Revision
+    public boolean selectedRevDeleted(){
+        return isSelectedRevFlags(C4RevisionFlags.kRevDeleted);
+    }
+    public boolean selectedRevLeaf(){
+        return isSelectedRevFlags(C4RevisionFlags.kRevLeaf);
+    }
+    public boolean selectedRevNew(){
+        return isSelectedRevFlags(C4RevisionFlags.kRevNew);
+    }
+    public boolean selectedRevHasAttachments(){
+        return isSelectedRevFlags(C4RevisionFlags.kRevHasAttachments);
+    }
+    private boolean isSelectedRevFlags(int flag){
+        return (_selectedRevFlags & flag) == flag;
+    }
 }

--- a/Java/src/com/couchbase/cbforest/Document.java
+++ b/Java/src/com/couchbase/cbforest/Document.java
@@ -25,6 +25,9 @@ public class Document {
 
     public native boolean selectNextLeaf(boolean includeDeleted, boolean withBody) throws ForestException;
 
+    public boolean hasRevisionBody(){
+        return hasRevisionBody(_handle);
+    }
 
     public String getSelectedRevID()        { return _selectedRevID; }
 
@@ -57,6 +60,9 @@ public class Document {
 
     public native void save(int maxRevTreeDepth) throws ForestException;
 
+    public int purgeRevision(String revID) throws ForestException {
+        return purgeRevision(_handle, revID);
+    }
     // INTERNALS:
 
     Document(long dbHandle, String docID, boolean mustExist) throws ForestException {
@@ -64,7 +70,10 @@ public class Document {
         _docID = docID;
         _revID = _selectedRevID;
     }
-
+    Document(long dbHandle, long sequence) throws ForestException {
+        _handle = initWithSequence(dbHandle, sequence);
+        _revID = _selectedRevID;
+    }
     Document(long docHandle) {
         _handle = docHandle;
         _docID = initWithDocHandle(docHandle);
@@ -72,10 +81,15 @@ public class Document {
     }
 
     private native long init(long dbHandle, String docID, boolean mustExist) throws ForestException;
+    private native long initWithSequence(long dbHandle, long sequence) throws ForestException;
     private native String initWithDocHandle(long docHandle);
 
     private native static String getType(long handle);
     private native static void setType(long handle, String type);
+
+    private native static boolean hasRevisionBody(long handle);
+
+    private native static int purgeRevision(long handle, String revID) throws ForestException;
 
     private native static void free(long handle);
     private native byte[] readSelectedBody() throws ForestException;

--- a/Java/src/com/couchbase/cbforest/DocumentIterator.java
+++ b/Java/src/com/couchbase/cbforest/DocumentIterator.java
@@ -1,6 +1,6 @@
 package com.couchbase.cbforest;
 
-class DocumentIterator {
+public class DocumentIterator {
     DocumentIterator(long handle, boolean dummy) {
         _handle = handle;
     }


### PR DESCRIPTION
New binding methods:
- Database.rekey()
- Database.compact()
- Database.getDocumentBySequence(long)
- Document.hasRevisionBody()
- Document.purgeRevision()

Others:
- Added helper methods to JNI Java code