### PR TITLE
Fix for c4doc_insertRevisionWithHistory and its JNI binding code

### DIFF
--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -644,7 +644,7 @@ int c4doc_insertRevisionWithHistory(C4Document *doc,
     try {
         std::vector<revidBuffer> revIDBuffers;
         std::vector<revid> revIDs;
-        revIDs.push_back(revidBuffer(revID));
+        //revIDs.push_back(revidBuffer(revID));
         for (unsigned i = 0; i < historyCount; i++) {
             revIDBuffers.push_back(revidBuffer(history[i]));
             revIDs.push_back(revIDBuffers.back());


### PR DESCRIPTION
- The caller method of `c4doc_insertRevisionWithHistory()`  already adds revID in the history. As alternate solution, we could fix caller method which is common code for both SQLIte and ForestDB.
- jobjectArray jhistory is String[]. So fixed binding codes.