### PR TITLE
Fixed insertRevisionWithHistory method related issues.

### DIFF
--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -642,17 +642,21 @@ int c4doc_insertRevisionWithHistory(C4Document *doc,
         return false;
     int commonAncestor = -1;
     try {
-        std::vector<revidBuffer> revIDBuffers;
-        std::vector<revid> revIDs;
-        //revIDs.push_back(revidBuffer(revID));
+        std::vector <revidBuffer*> revIDBuffers;
+        std::vector <revid> revIDs;
         for (unsigned i = 0; i < historyCount; i++) {
-            revIDBuffers.push_back(revidBuffer(history[i]));
-            revIDs.push_back(revIDBuffers.back());
+            revIDBuffers.push_back(new revidBuffer(history[i]));
+            revIDs.push_back(*revIDBuffers.back());
         }
+        
         commonAncestor = idoc->_versionedDoc.insertHistory(revIDs,
                                                            body,
                                                            deleted,
                                                            hasAttachments);
+
+        for (unsigned i = 0; i < historyCount; i++)
+            delete revIDBuffers.at(i);
+
         if (commonAncestor >= 0) {
             idoc->updateMeta();
             idoc->selectRevision(idoc->_versionedDoc[revidBuffer(revID)]);

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -644,7 +644,7 @@ int c4doc_insertRevisionWithHistory(C4Document *doc,
     try {
         std::vector<revidBuffer> revIDBuffers;
         std::vector<revid> revIDs;
-        revIDs.push_back(revidBuffer(revID));
+        //revIDs.push_back(revidBuffer(revID));
         for (unsigned i = 0; i < historyCount; i++) {
             revIDBuffers.push_back(revidBuffer(history[i]));
             revIDs.push_back(revIDBuffers.back());

--- a/CBForest/VersionedDocument.cc
+++ b/CBForest/VersionedDocument.cc
@@ -111,6 +111,9 @@ namespace forestdb {
             flags = kDeleted;
         }
 
+        // update _flags instance variable
+        _flags = flags;
+
         // Write to _doc.meta:
         slice meta = _doc.resizeMeta(2 + revID.size + SizeOfVarInt(_docType.size) + _docType.size);
         meta.writeFrom(slice(&flags,1));

--- a/Java/jni/native_document.cc
+++ b/Java/jni/native_document.cc
@@ -280,8 +280,10 @@ JNIEXPORT jint JNICALL Java_com_couchbase_cbforest_Document_insertRevisionWithHi
             delete historyAlloc.at(i);
         historyAlloc.clear();
     }
-    if (inserted >= 0)
+    if (inserted >= 0) {
+        updateSelection(env, self, doc);
         updateRevIDAndFlags(env, self, doc);
+    }
     else
         throwError(env, error);
     return inserted;


### PR DESCRIPTION
Changes from first commit:
- The caller method of `c4doc_insertRevisionWithHistory()`  already adds revID in the history. As alternate solution, we could fix caller method which is common code for both SQLIte and ForestDB.
- jobjectArray jhistory is String[]. So fixed binding codes.

Changes from second commit:
- CBForest/VersionedDocument: update _flags instance variable when updateMeta() method is called.
- c4Database.cc: revidBuffer(history[i]) was local variable. When exit from for-loop scope, revidBuffer's destractor was called. To avoid this problem use `new revidBuffer()`
- native_document.cc: call updateSelectin() method to update currently selected revision information in insertRevisionWithHistory(). otherwise, need to call selectCurrentRev() method.

NOTE: Removing Line 647 of c4Database.cc `revIDs.push_back(revidBuffer(revID));` is still discussion item.