### PR TITLE
Fixed insertRevisionWithHistory method related issues.

### DIFF
--- a/CBForest/VersionedDocument.cc
+++ b/CBForest/VersionedDocument.cc
@@ -111,6 +111,9 @@ namespace forestdb {
             flags = kDeleted;
         }
 
+        // update _flags instance variable
+        _flags = flags;
+
         // Write to _doc.meta:
         slice meta = _doc.resizeMeta(2 + revID.size + SizeOfVarInt(_docType.size) + _docType.size);
         meta.writeFrom(slice(&flags,1));

--- a/Java/jni/native_document.cc
+++ b/Java/jni/native_document.cc
@@ -261,22 +261,28 @@ JNIEXPORT jint JNICALL Java_com_couchbase_cbforest_Document_insertRevisionWithHi
         // Convert jhistory, a Java String[], to a C array of C4Slice:
         jsize n = env->GetArrayLength(jhistory);
         C4Slice history[n];
-        std::vector<alloc_slice> historyAlloc;
+        std::vector<jstringSlice*> historyAlloc;
         for (jsize i = 0; i < n; i++) {
-            jbyteArray jitem = (jbyteArray) env->GetObjectArrayElement(jhistory, i);
-            alloc_slice item = jbyteArraySlice::copy(env, jitem);
+            jstring js = (jstring)env->GetObjectArrayElement(jhistory, i);
+            jstringSlice *item = new jstringSlice(env, js);
             historyAlloc.push_back(item); // so its memory won't be freed
-            history[i] = (C4Slice){item.buf, item.size};
-            env->DeleteLocalRef(jitem);
+            history[i] = *item;
         }
 
         jbyteArraySlice body(env, jbody, true); // critical
         inserted = c4doc_insertRevisionWithHistory(doc, body, deleted, hasAtt,
                                                    history, n,
                                                    &error);
+
+        // release memory
+        for (jsize i = 0; i < n; i++)
+            delete historyAlloc.at(i);
+        historyAlloc.clear();
     }
-    if (inserted >= 0)
+    if (inserted >= 0) {
+        updateSelection(env, self, doc);
         updateRevIDAndFlags(env, self, doc);
+    }
     else
         throwError(env, error);
     return inserted;


### PR DESCRIPTION
@snej Thank you for your fix for insertRevisionWithHistory() method and test for it. This PR is fixes for other issues related with insertRevisionWithHistory().

Changes:
- VersionedDocument: update _flags instance variable when updateMeta() method is called.
- native_document.cc: call updateSelectin() method to update currently selected revision information in insertRevisionWithHistory(). otherwise, need to call selectCurrentRev() method.
- native_document.cc:  jobjectArray jhistory is String[]. So fixed binding codes.