### PR TITLE
Fixed CBForest and JNI to address View related issues.

### DIFF
--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -710,6 +710,7 @@ bool c4doc_save(C4Document *doc,
     try {
         idoc->_versionedDoc.prune(maxRevTreeDepth);
         idoc->_versionedDoc.save(*idoc->_db->transaction());
+        idoc->sequence = idoc->_versionedDoc.sequence();
         return true;
     } catchError(outError)
     return false;

--- a/CBForest/Collatable.cc
+++ b/CBForest/Collatable.cc
@@ -18,6 +18,7 @@
 #include "Geohash.hh"
 #include "Error.hh"
 #include <sstream>
+#include <iomanip> // std::setprecision
 
 namespace forestdb {
 
@@ -292,7 +293,9 @@ namespace forestdb {
                 break;
             case kNegative:
             case kPositive:
-                out << readDouble();
+                // default precision is around 5, it makes double number rounded.
+                // double's precision should be 16.
+                out << std::setprecision(16) << readDouble();
                 break;
             case kString:
                 writeJSONString(out, readString());

--- a/Java/jni/native_database.cc
+++ b/Java/jni/native_database.cc
@@ -132,19 +132,6 @@ JNIEXPORT jboolean JNICALL Java_com_couchbase_cbforest_Database_isInTransaction
 }
 
 
-JNIEXPORT jlong JNICALL Java_com_couchbase_cbforest_Database__1iterateChanges
-(JNIEnv *env, jobject self, jlong since, jboolean bodies)
-{
-    C4ChangesOptions options = kC4DefaultChangesOptions;
-    options.includeBodies = bodies;
-    C4Error error;
-    C4DocEnumerator* e = c4db_enumerateChanges(getDbHandle(env, self), since, &options, &error);
-    if (!e)
-        throwError(env, error);
-    return (jlong)e;
-}
-
-
 #pragma mark - LOGGING:
 
 

--- a/Java/jni/native_documentiterator.cc
+++ b/Java/jni/native_documentiterator.cc
@@ -15,12 +15,22 @@
 using namespace forestdb::jni;
 
 JNIEXPORT jlong JNICALL Java_com_couchbase_cbforest_DocumentIterator_initEnumerateAllDocs
-        (JNIEnv *env, jobject self, jlong dbHandle, jstring jStartDocID, jstring jEndDocID)
+        (JNIEnv *env, jobject self, jlong dbHandle, jstring jStartDocID, jstring jEndDocID,
+         jboolean descending, jboolean inclusiveStart, jboolean inclusiveEnd,
+         jint skip, jboolean includeDeleted, jboolean includeBodies)
 {
     jstringSlice startDocID(env, jStartDocID);
     jstringSlice endDocID(env, jEndDocID);
+    const C4AllDocsOptions options = {
+            (bool)descending,
+            (bool)inclusiveStart,
+            (bool)inclusiveEnd,
+            (unsigned)skip,
+            (bool)includeDeleted,
+            (bool)includeBodies
+    };
     C4Error error;
-    C4DocEnumerator *e = c4db_enumerateAllDocs((C4Database*)dbHandle, startDocID, endDocID, NULL, &error);
+    C4DocEnumerator *e = c4db_enumerateAllDocs((C4Database*)dbHandle, startDocID, endDocID, &options, &error);
     if (!e) {
         throwError(env, error);
         return 0;
@@ -68,10 +78,12 @@ JNIEXPORT jlong JNICALL Java_com_couchbase_cbforest_DocumentIterator_initEnumera
 
 
 JNIEXPORT jlong JNICALL Java_com_couchbase_cbforest_DocumentIterator_initEnumerateChanges
-        (JNIEnv *env, jobject self, jlong dbHandle, jlong since)
+        (JNIEnv *env, jobject self, jlong dbHandle, jlong since, jboolean withBodies)
 {
+    C4ChangesOptions options = kC4DefaultChangesOptions;
+    options.includeBodies = withBodies;
     C4Error error;
-    C4DocEnumerator *e = c4db_enumerateChanges((C4Database*)dbHandle, since, NULL, &error);
+    C4DocEnumerator *e = c4db_enumerateChanges((C4Database*)dbHandle, since, &options, &error);
     if (!e) {
         throwError(env, error);
         return 0;

--- a/Java/jni/native_queryIterator.cc
+++ b/Java/jni/native_queryIterator.cc
@@ -75,7 +75,11 @@ JNIEXPORT jstring JNICALL Java_com_couchbase_cbforest_QueryIterator_docID
 {
     return toJString(env, getEnum(env, self)->docID);
 }
-
+JNIEXPORT jlong JNICALL Java_com_couchbase_cbforest_QueryIterator_sequence
+        (JNIEnv *env, jobject self)
+{
+    return getEnum(env, self)->docSequence;
+}
 JNIEXPORT void JNICALL Java_com_couchbase_cbforest_QueryIterator_free
 (JNIEnv *env, jobject self)
 {

--- a/Java/jni/native_view.cc
+++ b/Java/jni/native_view.cc
@@ -212,6 +212,10 @@ JNIEXPORT jlong JNICALL Java_com_couchbase_cbforest_View_query__JJJZZZ_3J
     size_t keyCount = env->GetArrayLength(jkeys);
     jboolean isCopy;
     auto keys = env->GetLongArrayElements(jkeys, &isCopy);
+    C4Key *c4keys[keyCount];
+    for(int i = 0; i < keyCount; i++){
+        c4keys[i]   = (C4Key *)keys[i];
+    }
     C4QueryOptions options = {
         (uint64_t)std::max(skip, 0ll),
         (uint64_t)std::max(limit, 0ll),
@@ -222,7 +226,7 @@ JNIEXPORT jlong JNICALL Java_com_couchbase_cbforest_View_query__JJJZZZ_3J
         NULL,
         kC4SliceNull,
         kC4SliceNull,
-        (const C4Key**)keys,
+        (const C4Key **)c4keys,
         keyCount
     };
     C4Error error;

--- a/Java/src/com/couchbase/cbforest/Constants.java
+++ b/Java/src/com/couchbase/cbforest/Constants.java
@@ -217,7 +217,14 @@ public interface Constants {
         int POSIXDomain = 1;        // code is an errno
         int ForestDBDomain = 2;     // code is a fdb_status
         int C4Domain = 3;           // code is C4-specific code (TBD)
+    }
 
+    // Extra status codes not defined by fdb_errors.h
+    interface CBForestError {
+        int BadRevisionID = -1000;
+        int CorruptRevisionData = -1001;
+        int CorruptIndexData = -1002;
+        int AssertionFailed = -1003;
     }
 
     // C4Domain error codes:

--- a/Java/src/com/couchbase/cbforest/Database.java
+++ b/Java/src/com/couchbase/cbforest/Database.java
@@ -40,24 +40,24 @@ public class Database {
         return new Document(_handle, sequence);
     }
 
-    public DocumentIterator iterator() throws ForestException {
-        return new DocumentIterator(_handle);
-    }
-
-    public DocumentIterator iterator(String startDocID, String endDocID) throws ForestException {
-        return new DocumentIterator(_handle, startDocID, endDocID);
+    public DocumentIterator iterator(String startDocID,
+                                     String endDocID,
+                                     boolean descending,
+                                     boolean inclusiveStart,
+                                     boolean inclusiveEnd,
+                                     int skip,
+                                     boolean includeDeleted,
+                                     boolean includeBodies)
+            throws ForestException {
+        return new DocumentIterator(_handle, startDocID, endDocID, descending, inclusiveStart, inclusiveEnd, skip, includeDeleted, includeBodies);
     }
 
     public DocumentIterator iterator(String[] docIDs) throws ForestException {
         return new DocumentIterator(_handle, docIDs);
     }
 
-    public DocumentIterator iterator(long sinceSequence) throws ForestException {
-        return new DocumentIterator(_handle, sinceSequence);
-    }
-
     public DocumentIterator iterateChanges(long sinceSequence, boolean withBodies) throws ForestException {
-        return new DocumentIterator(_iterateChanges(sinceSequence, withBodies));
+        return new DocumentIterator(_handle, sinceSequence, withBodies);
     }
 
     protected void finalize() {
@@ -69,7 +69,6 @@ public class Database {
 
     private native long _open(String path, int flags,
                               int encryptionAlgorithm, byte[] encryptionKey) throws ForestException;
-    private native long _iterateChanges(long sinceSequence, boolean withBodies) throws ForestException;
 
     long _handle; // handle to native C4Database*
 

--- a/Java/src/com/couchbase/cbforest/Document.java
+++ b/Java/src/com/couchbase/cbforest/Document.java
@@ -6,6 +6,8 @@ public class Document implements Constants{
 
     public String getRevID()        { return _revID; }
 
+    public long getSequence()       { return _sequence; }
+
     public int getFlags()           { return _flags; }
 
     public String getType()         { return getType(_handle); }
@@ -95,6 +97,7 @@ public class Document implements Constants{
 
     protected long _handle;
     private String _docID, _revID;
+    private long _sequence;
     private int _flags;
 
     private String _selectedRevID;

--- a/Java/src/com/couchbase/cbforest/DocumentIterator.java
+++ b/Java/src/com/couchbase/cbforest/DocumentIterator.java
@@ -5,20 +5,30 @@ public class DocumentIterator {
         _handle = handle;
     }
 
-    DocumentIterator(long dbHandle) throws ForestException {
-        _handle = initEnumerateAllDocs(dbHandle, null, null);
-    }
-
-    DocumentIterator(long dbHandle, String startDocID, String endDocID) throws ForestException {
-        _handle = initEnumerateAllDocs(dbHandle, startDocID, endDocID);
+    DocumentIterator(long dbHandle,
+                     String startDocID,
+                     String endDocID,
+                     boolean descending,
+                     boolean inclusiveStart,
+                     boolean inclusiveEnd,
+                     int skip,
+                     boolean includeDeleted,
+                     boolean includeBodies)
+            throws ForestException {
+        _handle = initEnumerateAllDocs(dbHandle, startDocID, endDocID, descending,
+                inclusiveStart,
+                inclusiveEnd,
+                skip,
+                includeDeleted,
+                includeBodies);
     }
 
     DocumentIterator(long dbHandle, String[] docIDs) throws ForestException {
         _handle = initEnumerateSomeDocs(dbHandle, docIDs);
     }
 
-    DocumentIterator(long dbHandle, long sinceSequence) throws ForestException {
-        _handle = initEnumerateChanges(dbHandle, sinceSequence);
+    DocumentIterator(long dbHandle, long sinceSequence, boolean withBodies) throws ForestException {
+        _handle = initEnumerateChanges(dbHandle, sinceSequence, withBodies);
     }
 
     // Returns null at end
@@ -35,8 +45,17 @@ public class DocumentIterator {
 
     protected void finalize()       { free(); }
 
-    private native long initEnumerateChanges(long dbHandle, long sinceSequence) throws ForestException;
-    private native long initEnumerateAllDocs(long dbHandle, String startDocID, String endDocID) throws ForestException;
+    private native long initEnumerateChanges(long dbHandle, long sinceSequence, boolean withBodies) throws ForestException;
+    private native long initEnumerateAllDocs(long dbHandle,
+                                             String startDocID,
+                                             String endDocID,
+                                             boolean descending,
+                                             boolean inclusiveStart,
+                                             boolean inclusiveEnd,
+                                             int skip,
+                                             boolean includeDeleted,
+                                             boolean includeBodies)
+            throws ForestException;
     private native long initEnumerateSomeDocs(long dbHandle, String[] docIDs) throws ForestException;
     private native static long nextDocumentHandle(long handle) throws ForestException;
     private native static void free(long handle);

--- a/Java/src/com/couchbase/cbforest/QueryIterator.java
+++ b/Java/src/com/couchbase/cbforest/QueryIterator.java
@@ -11,6 +11,7 @@ public class QueryIterator {
     public native byte[] keyJSON();
     public native byte[] valueJSON();
     public native String docID();
+    public native long   sequence();
 
     public native void free();
 

--- a/Java/src/com/couchbase/cbforest/View.java
+++ b/Java/src/com/couchbase/cbforest/View.java
@@ -53,7 +53,7 @@ public class View {
         _indexerHandle = beginIndex(_dbHandle, _handle);
     }
 
-    public DocumentIterator enumerator() {
+    public DocumentIterator enumerator() throws ForestException {
         return new DocumentIterator(enumerateDocuments(_indexerHandle), false);
     }
 
@@ -76,7 +76,7 @@ public class View {
 
     // native methods for indexer
     private native long beginIndex(long dbHandle, long viewHandle) throws ForestException;
-    private native long enumerateDocuments(long indexerHandler);
+    private native long enumerateDocuments(long indexerHandler) throws ForestException;
     private native void emit(long indexerHandler, long docHandler, long[] keys, byte[][] values) throws ForestException;
     private native void endIndex(long indexerHandler, boolean commit) throws ForestException;
     // NOTE: endIndex also frees Indexer
@@ -98,10 +98,16 @@ public class View {
                                String startKeyDocID,
                                String endKeyDocID) throws ForestException
     {
-        return new QueryIterator(query(_handle, skip, limit, descending,
-                                       inclusiveStart, inclusiveEnd,
-                                       objectToKey(startKey), objectToKey(endKey),
-                                       startKeyDocID, endKeyDocID));
+        return new QueryIterator(query(_handle,
+                skip,
+                limit,
+                descending,
+                inclusiveStart,
+                inclusiveEnd,
+                objectToKey(startKey),
+                objectToKey(endKey),
+                startKeyDocID,
+                endKeyDocID));
     }
 
 
@@ -142,7 +148,8 @@ public class View {
                                      boolean descending,
                                      boolean inclusiveStart,
                                      boolean inclusiveEnd,
-                                     long keys[]) throws ForestException; // array of C4Key*
+                                     long keys[])  // array of C4Key*
+            throws ForestException;
 
 
     //////// KEY:
@@ -174,7 +181,7 @@ public class View {
         } else if (o instanceof String) {
             keyAdd(key, (String)o);
         } else if (o instanceof Object[]) {
-            Object[] array = (Object[])o;
+            keyBeginArray(key);
             for (Object item : (Object[])o) {
                 keyAdd(key, item);
             }


### PR DESCRIPTION
CBForest:
- c4Database.cc: Update C4Document.sequence value after save the document
- Collatable.cc: set precision level to isotherm for double value

JNI:
- Added sequence into Document which is transferred value between Java and Native
- Make initEnumerateAllDocs to support all option values
- Make query iterator can return document sequence value
- Fixed the C4Key array passing issue for query
- Update initWithDocHandle(...) in native_document.cc : Added to call c4doc_selectCurrentRevision(doc) to select current revision, and removed redundant Java instance variable update methods, which are covered by udpateSelection() and updateRevIDAndFlags().
- Consolidated Database.iterateChanges(...) and DocumentIterator.initEnumerateChanges(...)
- Constants.java: Added CBForestError constants