### PR TITLE
Fixed JNI compilation error and runtime errors with Java (JDK) on OS X

### DIFF
--- a/C/c4View.cc
+++ b/C/c4View.cc
@@ -10,7 +10,8 @@
 #include "c4View.h"
 #include "Collatable.hh"
 #include "MapReduceIndex.hh"
-
+#include <math.h>
+#include <limits.h>
 using namespace forestdb;
 
 

--- a/CBForest/GeoIndex.cc
+++ b/CBForest/GeoIndex.cc
@@ -17,6 +17,7 @@
 #include "LogInternal.hh"
 #include <math.h>
 #include <set>
+#include <algorithm>
 
 
 namespace forestdb {

--- a/Java/jni/native_glue.cc
+++ b/Java/jni/native_glue.cc
@@ -42,8 +42,12 @@ namespace forestdb {
         :_env(env),
          _jstr(js)
         {
-            jboolean isCopy;
-            _cstr = env->GetStringUTFChars(js, &isCopy);
+            if(js == NULL){
+                _cstr = NULL;
+            }else{
+                jboolean isCopy;
+                _cstr = env->GetStringUTFChars(js, &isCopy);
+            }
             _slice = slice(_cstr);
         }
 

--- a/Java/jni/native_glue.hh
+++ b/Java/jni/native_glue.hh
@@ -29,6 +29,10 @@ public:
     jstringSlice(JNIEnv *env, jstring js);
     ~jstringSlice();
 
+    jstringSlice(jstringSlice&& s) // move constructor
+    :_slice(s._slice), _env(s._env), _jstr(s._jstr), _cstr(s._cstr)
+    { s._slice = slice::null; }
+
     operator slice()    {return _slice;}
     operator C4Slice()  {return (C4Slice){_slice.buf, _slice.size};}
 
@@ -45,6 +49,10 @@ class jbyteArraySlice {
 public:
     jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, bool critical =false);
     ~jbyteArraySlice();
+
+    jbyteArraySlice(jbyteArraySlice&& s) // move constructor
+    :_slice(s._slice), _env(s._env), _jbytes(s._jbytes), _critical(s._critical)
+    { s._slice = slice::null; }
 
     operator slice()    {return _slice;}
     operator C4Slice()  {return (C4Slice){_slice.buf, _slice.size};}

--- a/Java/jni/native_view.cc
+++ b/Java/jni/native_view.cc
@@ -149,26 +149,24 @@ JNIEXPORT void JNICALL Java_com_couchbase_cbforest_View_emit(JNIEnv *env, jobjec
     jlong *keys   = env->GetLongArrayElements(jkeys, NULL);
     C4Key *c4keys[count];
     C4Slice c4values[count];
-    std::vector<jbyteArraySlice*> valueBufs;
+    std::vector<jbyteArraySlice> valueBufs;
     for(int i = 0; i < count; i++) {
         c4keys[i] = (C4Key*)keys[i];
         jbyteArray jvalue = (jbyteArray) env->GetObjectArrayElement(jvalues, i);
         if (jvalue) {
-            jbyteArraySlice* ptr = new  jbyteArraySlice(env, jvalue);
-            valueBufs.push_back(ptr);
-            //valueBufs.push_back(jbyteArraySlice(env, jvalue));
-            c4values[i] = *valueBufs.back();
+            valueBufs.push_back(jbyteArraySlice(env, jvalue));
+            c4values[i] = valueBufs.back();
         } else {
             c4values[i] = kC4SliceNull;
         }
     }
+
     C4Error error;
     bool result = c4indexer_emit(indexer, doc, 0, (unsigned)count,
                                  c4keys, c4values, &error);
-    for(int i = 0; i < count; i++){
+
+    for(int i = 0; i < count; i++)
         c4key_free(c4keys[i]);
-        delete valueBufs.at(i);
-    }
     env->ReleaseLongArrayElements(jkeys, keys, JNI_ABORT);
 
     if(!result)

--- a/Java/jni/native_view.cc
+++ b/Java/jni/native_view.cc
@@ -149,24 +149,26 @@ JNIEXPORT void JNICALL Java_com_couchbase_cbforest_View_emit(JNIEnv *env, jobjec
     jlong *keys   = env->GetLongArrayElements(jkeys, NULL);
     C4Key *c4keys[count];
     C4Slice c4values[count];
-    std::vector<jbyteArraySlice> valueBufs;
+    std::vector<jbyteArraySlice*> valueBufs;
     for(int i = 0; i < count; i++) {
         c4keys[i] = (C4Key*)keys[i];
         jbyteArray jvalue = (jbyteArray) env->GetObjectArrayElement(jvalues, i);
         if (jvalue) {
-            valueBufs.push_back(jbyteArraySlice(env, jvalue));
-            c4values[i] = valueBufs.back();
+            jbyteArraySlice* ptr = new  jbyteArraySlice(env, jvalue);
+            valueBufs.push_back(ptr);
+            //valueBufs.push_back(jbyteArraySlice(env, jvalue));
+            c4values[i] = *valueBufs.back();
         } else {
             c4values[i] = kC4SliceNull;
         }
     }
-
     C4Error error;
     bool result = c4indexer_emit(indexer, doc, 0, (unsigned)count,
                                  c4keys, c4values, &error);
-
-    for(int i = 0; i < count; i++)
+    for(int i = 0; i < count; i++){
         c4key_free(c4keys[i]);
+        delete valueBufs.at(i);
+    }
     env->ReleaseLongArrayElements(jkeys, keys, JNI_ABORT);
 
     if(!result)
@@ -200,8 +202,8 @@ JNIEXPORT jlong JNICALL Java_com_couchbase_cbforest_View_query__JJJZZZJJLjava_la
 {
     jstringSlice startKeyDocID(env, jstartKeyDocID), endKeyDocID(env, jendKeyDocID);
     C4QueryOptions options = {
-        (uint64_t)std::max(skip, 0ll),
-        (uint64_t)std::max(limit, 0ll),
+        (uint64_t)std::max((long long)skip, 0ll),
+        (uint64_t)std::max((long long)limit, 0ll),
         (bool)descending,
         (bool)inclusiveStart,
         (bool)inclusiveEnd,
@@ -232,8 +234,8 @@ JNIEXPORT jlong JNICALL Java_com_couchbase_cbforest_View_query__JJJZZZ_3J
         c4keys[i]   = (C4Key *)keys[i];
     }
     C4QueryOptions options = {
-        (uint64_t)std::max(skip, 0ll),
-        (uint64_t)std::max(limit, 0ll),
+        (uint64_t)std::max((long long)skip, 0ll),
+        (uint64_t)std::max((long long)limit, 0ll),
         (bool)descending,
         (bool)inclusiveStart,
         (bool)inclusiveEnd,


### PR DESCRIPTION
- compile error with `std::max`: it requires exact same type.
- `valueBufs.push_back(jbyteArraySlice(env, jvalue));` caused malloc/free error on OS X
- calling GetStringUTFChars with null jstring parameter causes runtime crash on OS X