### PR TITLE
C API: Fixes for C4Documents loaded without their bodies

### DIFF
--- a/Java/jni/native_document.cc
+++ b/Java/jni/native_document.cc
@@ -103,8 +103,7 @@ JNIEXPORT jstring JNICALL Java_com_couchbase_cbforest_Document_initWithDocHandle
 {
     auto doc = (C4Document*)docHandle;
     updateRevIDAndFlags(env, self, doc);
-    if(c4doc_selectCurrentRevision(doc))
-        updateSelection(env, self, doc);
+    updateSelection(env, self, doc);
     return toJString(env, doc->docID);
 }
 JNIEXPORT jboolean JNICALL Java_com_couchbase_cbforest_Document_hasRevisionBody


### PR DESCRIPTION
* c4doc_selectCurrentRevision doesn't need to load the doc body.
* Warn if trying to select other revisions when the doc body isn't loaded.
* Fixed some error handling in the insert-revision methods
* JNI method Document.initWithDocHandle doesn't need to select the
  current revision; it's already selected by default.

This should improve performance of all-docs enumeration in Java, because
it no longer ends up loading the bodies of all the documents.