### PR TITLE
JNI optimization for Document (speed up updateSelection fn)

### DIFF
--- a/C/c4.exp
+++ b/C/c4.exp
@@ -4,6 +4,7 @@
 #  Created by Jens Alfke on 9/15/15.
 #  Copyright © 2015 Couchbase. All rights reserved.
 
+_c4SliceEqual
 _c4slice_free
 _c4log_register
 

--- a/C/c4.h
+++ b/C/c4.h
@@ -141,7 +141,10 @@ const C4Slice kC4SliceNull = { NULL, 0 };
 
 #endif // C4_IMPL
 
-/** Frees the memory of a heap-allocated slice by calling free(chars). */
+/** Returns true if two slices have equal contents. */
+bool c4SliceEqual(C4Slice a, C4Slice b);
+
+/** Frees the memory of a heap-allocated slice by calling free(buf). */
 void c4slice_free(C4Slice);
 
 

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -52,6 +52,11 @@ namespace c4Internal {
 }
 
 
+bool c4SliceEqual(C4Slice a, C4Slice b) {
+    return a == b;
+}
+
+
 void c4slice_free(C4Slice slice) {
     slice.free();
 }


### PR DESCRIPTION
If the current revision is selected, the Java String in Document.revID can be stored into .selectedRevID instead of creating another String. This will save creating an object every time a Document is initialized, and may speed up the allDocuments iteration.

Hideki, could you please try this, and merge it if it works?