### PR TITLE
Java: Support for simultaneous indexing of multiple views

### DIFF
--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -156,6 +156,10 @@ namespace c4Internal {
     C4Document* newC4Document(C4Database *db, const Document &doc) {
         return new C4DocumentInternal(db, doc);
     }
+
+    const VersionedDocument& versionedDocument(C4Document* doc) {
+        return internal(doc)->_versionedDoc;
+    }
 }
 
 

--- a/C/c4Impl.hh
+++ b/C/c4Impl.hh
@@ -16,6 +16,10 @@
 
 using namespace forestdb;
 
+namespace forestdb {
+    class VersionedDocument;
+}
+
 
 // Predefine C4Slice as a typedef of slice so we can use the richer slice API:
 
@@ -60,6 +64,8 @@ namespace c4Internal {
     bool rekey(Database* database, const C4EncryptionKey *newKey, C4Error *outError);
 
     C4Document* newC4Document(C4Database*, const Document&);
+
+    const VersionedDocument& versionedDocument(C4Document*);
 
 }
 

--- a/CBForest.xcodeproj/project.pbxproj
+++ b/CBForest.xcodeproj/project.pbxproj
@@ -168,6 +168,8 @@
 		278270CE1C221E7E00F4786F /* c4DocEnumerator.cc in Sources */ = {isa = PBXBuildFile; fileRef = 278270CB1C221E7E00F4786F /* c4DocEnumerator.cc */; };
 		278270CF1C221E7E00F4786F /* c4DocEnumerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 278270CC1C221E7E00F4786F /* c4DocEnumerator.h */; };
 		278270D61C236ABD00F4786F /* c4DocEnumerator.cc in Sources */ = {isa = PBXBuildFile; fileRef = 278270CB1C221E7E00F4786F /* c4DocEnumerator.cc */; };
+		278270DE1C249C0800F4786F /* Indexer.java in Sources */ = {isa = PBXBuildFile; fileRef = 278270DD1C249C0800F4786F /* Indexer.java */; };
+		278270E01C24A1D000F4786F /* native_indexer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 278270DF1C24A1D000F4786F /* native_indexer.cc */; };
 		278EBFA01976325A006362F8 /* debug.cc in Sources */ = {isa = PBXBuildFile; fileRef = 278EBF93197631B1006362F8 /* debug.cc */; };
 		278EBFA11976325A006362F8 /* memleak.cc in Sources */ = {isa = PBXBuildFile; fileRef = 278EBF9B19763238006362F8 /* memleak.cc */; };
 		278EBFA31976325A006362F8 /* debug.cc in Sources */ = {isa = PBXBuildFile; fileRef = 278EBF93197631B1006362F8 /* debug.cc */; };
@@ -755,6 +757,8 @@
 		277D19C9194E295B008E91EB /* Error.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = Error.hh; path = ../CBForest/Error.hh; sourceTree = "<group>"; };
 		278270CB1C221E7E00F4786F /* c4DocEnumerator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = c4DocEnumerator.cc; sourceTree = "<group>"; };
 		278270CC1C221E7E00F4786F /* c4DocEnumerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = c4DocEnumerator.h; sourceTree = "<group>"; };
+		278270DD1C249C0800F4786F /* Indexer.java */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.java; name = Indexer.java; path = src/com/couchbase/cbforest/Indexer.java; sourceTree = "<group>"; };
+		278270DF1C24A1D000F4786F /* native_indexer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = native_indexer.cc; sourceTree = "<group>"; };
 		278EBF8F1976317D006362F8 /* btree_str_kv.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = btree_str_kv.cc; sourceTree = "<group>"; };
 		278EBF901976317D006362F8 /* btree_str_kv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = btree_str_kv.h; sourceTree = "<group>"; };
 		278EBF93197631B1006362F8 /* debug.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = debug.cc; path = vendor/forestdb/utils/debug.cc; sourceTree = SOURCE_ROOT; };
@@ -1082,6 +1086,7 @@
 				274D03EB1BA734A300FF7C35 /* native_documentiterator.cc */,
 				27FF7E5B1BAB8B72004EB8D4 /* native_queryIterator.cc */,
 				27FF7E551BAB64BE004EB8D4 /* native_view.cc */,
+				278270DF1C24A1D000F4786F /* native_indexer.cc */,
 				274D03EC1BA734A300FF7C35 /* native_glue.cc */,
 				274D03ED1BA734A300FF7C35 /* native_glue.hh */,
 			);
@@ -1335,6 +1340,7 @@
 				274D03F41BA734C100FF7C35 /* Document.java */,
 				274D03F51BA734C100FF7C35 /* DocumentIterator.java */,
 				274D03F61BA734C100FF7C35 /* ForestException.java */,
+				278270DD1C249C0800F4786F /* Indexer.java */,
 				27A82D0D1BBB2727005CB742 /* Logger.java */,
 				27FF7E581BAB65A2004EB8D4 /* QueryIterator.java */,
 				27FF7E541BAB60E2004EB8D4 /* View.java */,
@@ -2099,9 +2105,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				278270E01C24A1D000F4786F /* native_indexer.cc in Sources */,
 				274D03EE1BA734A300FF7C35 /* native_database.cc in Sources */,
 				274D03F91BA73B1600FF7C35 /* Database.java in Sources */,
 				274D03F11BA734A300FF7C35 /* native_glue.cc in Sources */,
+				278270DE1C249C0800F4786F /* Indexer.java in Sources */,
 				274D03FC1BA7418B00FF7C35 /* DocumentIterator.java in Sources */,
 				27FF7E561BAB64BE004EB8D4 /* native_view.cc in Sources */,
 				27FF7E5A1BAB8B0B004EB8D4 /* c4View.cc in Sources */,

--- a/CBForest/MapReduceIndex.hh
+++ b/CBForest/MapReduceIndex.hh
@@ -130,18 +130,28 @@ namespace forestdb {
 
         KeyStore sourceStore();
 
+        /** Updates all of the indexes by enumerating the new documents and calling addDocument()
+            on each one. (That method needs to be overridden for this to do anything.) */
         bool run();
 
+        /** Returns true if indexing completed successfully. */
         void finished()                             {_finished = true;}
 
         sequence latestDbSequence() const           {return _latestDbSequence;}
 
-        // Incremental mode:
+        //// Incremental mode:
 
         /** Determines at which sequence indexing should start.
             Returns UINT64_MAX if no re-indexing is necessary. */
         sequence startingSequence();
 
+        /** Returns true if the given document should be indexed by the given view,
+            i.e. if the view has not yet indexed this doc's sequence. */
+        bool shouldMapDocIntoView(const Document &doc, unsigned viewNumber);
+
+        /** Writes a set of key/value pairs into a view's index, associated with a doc/sequence.
+            This must be called even if there are no pairs to index, so that obsolete index rows
+            can be removed. */
         void emitDocIntoView(slice docID,
                              sequence docSequence,
                              unsigned viewNumber,

--- a/CBForest/VersionedDocument.hh
+++ b/CBForest/VersionedDocument.hh
@@ -56,6 +56,8 @@ namespace forestdb {
         bool exists() const         {return _doc.exists();}
         forestdb::sequence sequence() const {return _doc.sequence();}
 
+        const Document& document() const    {return _doc;}
+
         slice docType() const       {return _docType;}
         void setDocType(slice type) {_docType = type;}
 

--- a/Java/jni/native_glue.hh
+++ b/Java/jni/native_glue.hh
@@ -12,6 +12,7 @@
 #include <jni.h>
 #include "c4Database.h"
 #include "slice.hh"
+#include <vector>
 
 namespace forestdb {
     namespace jni {
@@ -67,17 +68,33 @@ private:
     bool _critical;
 };
 
-// Copies an encryption key to a C4EncryptionKey. Returns false on exception.
-bool getEncryptionKey(JNIEnv *env,
-                      jint keyAlg,
-                      jbyteArray jKeyBytes,
-                      C4EncryptionKey *outKey);
-
 jstring toJString(JNIEnv*, C4Slice);
 
 jbyteArray toJByteArray(JNIEnv*, C4Slice);
 
 void throwError(JNIEnv*, C4Error);
+
+// Copies an array of handles from a Java long[] to a C++ vector.
+template <typename T>
+std::vector<T> handlesToVector(JNIEnv *env, jlongArray jhandles) {
+    jsize count = env->GetArrayLength(jhandles);
+    std::vector<T> objects(count);
+    if (count > 0) {
+        jboolean isCopy;
+        auto handles = env->GetLongArrayElements(jhandles, &isCopy);
+        for(jsize i = 0; i < count; i++) {
+            objects[i] = (T)handles[i];
+        }
+        env->ReleaseLongArrayElements(jhandles, handles, JNI_ABORT);
+    }
+    return objects;
+}
+
+// Copies an encryption key to a C4EncryptionKey. Returns false on exception.
+bool getEncryptionKey(JNIEnv *env,
+                      jint keyAlg,
+                      jbyteArray jKeyBytes,
+                      C4EncryptionKey *outKey);
 
     }
 }

--- a/Java/jni/native_indexer.cc
+++ b/Java/jni/native_indexer.cc
@@ -1,0 +1,99 @@
+//
+//  native_indexer.cc
+//  CBForest
+//
+//  Created by Jens Alfke on 12/18/15.
+//  Copyright © 2015 Couchbase. All rights reserved.
+//
+
+#include "com_couchbase_cbforest_Indexer.h"
+#include "native_glue.hh"
+#include "c4View.h"
+#include <algorithm>
+#include <vector>
+
+
+using namespace forestdb::jni;
+
+
+JNIEXPORT jlong JNICALL Java_com_couchbase_cbforest_Indexer_beginIndex
+(JNIEnv *env, jclass clazz, jlong dbHandle, jlongArray viewHandles)
+{
+    auto c4views = handlesToVector<C4View*>(env, viewHandles);
+    C4Error error;
+    C4Indexer* indexer = c4indexer_begin((C4Database*)dbHandle, c4views.data(), c4views.size(), &error);
+    if (!indexer)
+        throwError(env, error);
+    return (jlong)indexer;
+}
+
+
+JNIEXPORT void JNICALL Java_com_couchbase_cbforest_Indexer_triggerOnView
+  (JNIEnv *env, jclass clazz, jlong indexerHandle, jlong viewHandle)
+{
+    auto indexer = (C4Indexer*)indexerHandle;
+    auto view = (C4View*)viewHandle;
+    c4indexer_triggerOnView(indexer, view);
+}
+
+
+JNIEXPORT jlong JNICALL Java_com_couchbase_cbforest_Indexer_iterateDocuments
+(JNIEnv *env, jclass clazz, jlong indexerHandle)
+{
+    C4Error error;
+    C4DocEnumerator* e = c4indexer_enumerateDocuments((C4Indexer*)indexerHandle, &error);
+    if(!e && error.code != 0)
+        throwError(env, error);
+    return (jlong)e;
+}
+
+
+JNIEXPORT jboolean JNICALL Java_com_couchbase_cbforest_Indexer_shouldIndex
+  (JNIEnv *env, jclass clazz, jlong indexerHandle, jlong docHandle, jint viewNumber)
+{
+    auto indexer = (C4Indexer*)indexerHandle;
+    auto doc = (C4Document*)docHandle;
+    return c4indexer_shouldIndexDocument(indexer, viewNumber, doc);
+}
+
+
+JNIEXPORT void JNICALL Java_com_couchbase_cbforest_Indexer_emit
+(JNIEnv *env, jclass clazz,
+ jlong indexerHandle, jlong documentHandler, jint viewNumber, jlongArray jkeys, jobjectArray jvalues)
+{
+    auto c4keys = handlesToVector<C4Key*>(env, jkeys);
+    size_t count = c4keys.size();
+    std::vector<C4Slice> c4values(count);
+    std::vector<jbyteArraySlice> valueBufs;
+    for(int i = 0; i < count; i++) {
+        jbyteArray jvalue = (jbyteArray) env->GetObjectArrayElement(jvalues, i);
+        if (jvalue) {
+            valueBufs.push_back(jbyteArraySlice(env, jvalue));
+            c4values[i] = valueBufs.back();
+        } else {
+            c4values[i] = kC4SliceNull;
+        }
+    }
+
+    C4Indexer* indexer = (C4Indexer*)indexerHandle;
+    C4Document* doc = (C4Document*)documentHandler;
+    C4Error error;
+    bool result = c4indexer_emit(indexer, doc, 0, (unsigned)count,
+                                 c4keys.data(), c4values.data(), &error);
+
+    for(int i = 0; i < count; i++)
+        c4key_free(c4keys[i]);
+
+    if(!result)
+        throwError(env, error);
+}
+
+
+JNIEXPORT void JNICALL Java_com_couchbase_cbforest_Indexer_endIndex
+(JNIEnv *env, jclass clazz, jlong indexerHandle, jboolean commit)
+{
+    C4Error error;
+    if(!c4indexer_end((C4Indexer *)indexerHandle, commit, &error))
+        throwError(env, error);
+}
+

--- a/Java/src/com/couchbase/cbforest/Indexer.java
+++ b/Java/src/com/couchbase/cbforest/Indexer.java
@@ -1,0 +1,65 @@
+package com.couchbase.cbforest;
+
+
+public class Indexer {
+
+    public Indexer(View[] views) throws ForestException {
+        long viewHandles[] = new long[views.length];
+        for (int i = 0; i < views.length; i++)
+            viewHandles[i] = views[i]._handle;
+        _handle = beginIndex(views[0]._dbHandle, viewHandles);
+    }
+
+    public void triggerOnView(View v) {
+        triggerOnView(_handle, v._handle);
+    }
+
+    public DocumentIterator iterateDocuments() throws ForestException {
+        long iterHandle = iterateDocuments(_handle);
+        if (iterHandle == 0)
+            return null;  // means there's nothing new to iterate
+        return new DocumentIterator(iterHandle, false);
+    }
+
+    public boolean shouldIndex(Document doc, int viewNumber) {
+        return shouldIndex(_handle, doc._handle, viewNumber);
+    }
+
+    public void emit(Document doc, int viewNumber, Object[] keys, byte[][] values) throws ForestException {
+
+        // initialize C4Key
+        long keyHandles[] = new long[keys.length];
+        for (int i = 0; i < keys.length; i++) {
+            keyHandles[i] = View.objectToKey(keys[i]);
+        }
+
+        emit(_handle, doc._handle, viewNumber, keyHandles, values);
+        // C4Keys in keyHandles are freed by the native method
+    }
+
+    public void endIndex(boolean commit) throws ForestException {
+        endIndex(_handle, commit);
+        _handle = 0;
+    }
+
+
+    // internals:
+
+    protected void finalize() {
+        if (_handle != 0) {
+            try {
+                endIndex(false);
+            } catch (Exception x) { }
+        }
+    }
+
+    private static native long beginIndex(long dbHandle, long viewHandles[]) throws ForestException;
+    private static native void triggerOnView(long handle, long viewHandle);
+    private static native long iterateDocuments(long handle) throws ForestException;
+    private static native boolean shouldIndex(long handle, long docHandle, int viewNumber);
+    private static native void emit(long handle, long docHandle, int viewNumber, long[] keys, byte[][] values) throws ForestException;
+    private static native void endIndex(long handle, boolean commit) throws ForestException;
+
+    private long _handle; // handle to native C4Indexer*
+
+}

--- a/Java/src/com/couchbase/cbforest/View.java
+++ b/Java/src/com/couchbase/cbforest/View.java
@@ -14,7 +14,6 @@ public class View {
         _dbHandle = sourceDB._handle;
         _handle = _open(sourceDB._handle, viewDbPath, viewDbFlags, encryptionAlgorithm,
                         encryptionKey, viewName, version);
-        _indexerHandle = 0;
     }
 
     protected void finalize() {
@@ -22,12 +21,6 @@ public class View {
     }
 
     public void closeView(){
-        if(_indexerHandle != 0) {
-            try {
-                endIndex(false);
-            } catch (ForestException e) {}
-        }
-
         close();
         _handle = 0;
         _dbHandle = 0;
@@ -48,41 +41,6 @@ public class View {
     protected long _handle;    // handle to native C4View*
     protected long _dbHandle; // handle to native C4Database*
 
-    //////// INDEXING:
-
-    public void beginIndex() throws ForestException {
-        _indexerHandle = beginIndex(_dbHandle, _handle);
-    }
-
-    public DocumentIterator enumerator() throws ForestException {
-        return new DocumentIterator(enumerateDocuments(_indexerHandle), false);
-    }
-
-    public void emit(Document doc, Object[] keys, byte[][] values) throws ForestException {
-
-        // initialize C4Key
-        long keyHandles[] = new long[keys.length];
-        for (int i = 0; i < keys.length; i++) {
-            keyHandles[i] = objectToKey(keys[i]);
-        }
-
-        emit(_indexerHandle, doc._handle, keyHandles, values);
-        // C4Keys in keyHandles are freed by the native method
-    }
-
-    public void endIndex(boolean commit) throws ForestException {
-        endIndex(_indexerHandle, commit);
-        _indexerHandle = 0;
-    }
-
-    // native methods for indexer
-    private native long beginIndex(long dbHandle, long viewHandle) throws ForestException;
-    private native long enumerateDocuments(long indexerHandler) throws ForestException;
-    private native void emit(long indexerHandler, long docHandler, long[] keys, byte[][] values) throws ForestException;
-    private native void endIndex(long indexerHandler, boolean commit) throws ForestException;
-    // NOTE: endIndex also frees Indexer
-
-    protected long _indexerHandle; // handle to native C4View*
 
     //////// QUERYING:
     public QueryIterator query() throws ForestException {


### PR DESCRIPTION
Broke the indexing API out into a new class, Indexer.
An Indexer is created with an array of views to be indexed.

Before calling a view's map function, call Indexer.shouldIndex to check
whether that view needs that sequence to be indexed; if not, skip it.

When emitting key/value pairs, you'll need to specify which view
they're for.