### PR TITLE
Fixed #53 - Fixed compilation error on Windows with VC++

### DIFF
--- a/CBForest/Collatable.cc
+++ b/CBForest/Collatable.cc
@@ -19,6 +19,7 @@
 #include "Error.hh"
 #include <sstream>
 #include <iomanip> // std::setprecision
+#include <algorithm> // std::max for MSVC
 
 namespace forestdb {
 

--- a/CBForest/slice.cc
+++ b/CBForest/slice.cc
@@ -21,10 +21,14 @@ namespace forestdb {
 
     int slice::compare(slice b) const {
         // Optimized for speed
-        if (this->size < b.size)
-            return memcmp(this->buf, b.buf, this->size) ?: -1;
-        else if (this->size > b.size)
-            return memcmp(this->buf, b.buf, b.size) ?: 1;
+        if (this->size < b.size) {
+            int ret = memcmp(this->buf, b.buf, this->size);
+            return ret ? ret : -1;
+        }
+        else if (this->size > b.size) {
+            int ret = memcmp(this->buf, b.buf, b.size);
+            return ret ? ret : 1;
+        }
         else
             return memcmp(this->buf, b.buf, this->size);
     }


### PR DESCRIPTION
- VC requires `#include <algorithm>` explicitly to use `std::max`
- VC does not support X?:Y