### PR TITLE
Fixed Java Core 935 - GrocerySync with ForesDB crashes during pull re…

### DIFF
--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -226,16 +226,19 @@ bool c4doc_selectRevision(C4Document* doc,
                           bool withBody,
                           C4Error *outError)
 {
-    auto idoc = internal(doc);
-    if (revID.buf) {
-        if (!idoc->loadRevisions(outError))
-            return false;
-        const Revision *rev = idoc->_versionedDoc[revidBuffer(revID)];
-        return idoc->selectRevision(rev, outError) && (!withBody || idoc->loadSelectedRevBody(outError));
-    } else {
-        idoc->selectRevision(NULL);
-        return true;
-    }
+    try {
+        auto idoc = internal(doc);
+        if (revID.buf) {
+            if (!idoc->loadRevisions(outError))
+                return false;
+            const Revision *rev = idoc->_versionedDoc[revidBuffer(revID)];
+            return idoc->selectRevision(rev, outError) && (!withBody || idoc->loadSelectedRevBody(outError));
+        } else {
+            idoc->selectRevision(NULL);
+            return true;
+        }
+    } catchError(outError);
+    return false;
 }
 
 


### PR DESCRIPTION
…plication (https://github.com/couchbase/couchbase-lite-java-core/issues/935)

Crash is caused by not catching exception which was caused by invalid RevID.