### PR TITLE
Disable GENERATE_MASTER_OBJECT_FILE setting in 'CBForest static' target

### DIFF
--- a/CBForest.xcodeproj/project.pbxproj
+++ b/CBForest.xcodeproj/project.pbxproj
@@ -2195,7 +2195,6 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				GENERATE_MASTER_OBJECT_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -2217,7 +2216,6 @@
 				DSTROOT = /tmp/CBForest_iOS.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CBForest/CBForest-Prefix.pch";
-				GENERATE_MASTER_OBJECT_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,


### PR DESCRIPTION
Disable GENERATE_MASTER_OBJECT_FILE in 'CBForest static' target to fix 'unable to open object file' warning messages.

For couchbase/couchbase-lite-ios#1054