### PR TITLE
Work around ForestDB bug in descending view queries

### DIFF
--- a/CBForest/Index.cc
+++ b/CBForest/Index.cc
@@ -221,6 +221,7 @@ namespace cbforest {
     static DocEnumerator::Options docOptions(DocEnumerator::Options options) {
         options.limit = DocEnumerator::Options::kDefault.limit;
         options.skip = DocEnumerator::Options::kDefault.skip;
+        options.includeDeleted = false;
         options.contentOptions = KeyStore::kDefaultContent; // read() method needs the doc bodies
         return options;
     }


### PR DESCRIPTION
ForestDB's iterator can stop prematurely when iterating in descending
order while skipping deleted docs. The workaround here avoids setting
the FDB_ITR_NO_DELETES flag. Have filed a ForestDB issue to get a real
fix.

Fixes #1082