### PR TITLE
Fix possible exception in previous fix (for descending view queries)

### DIFF
--- a/CBForest/DocEnumerator.cc
+++ b/CBForest/DocEnumerator.cc
@@ -216,8 +216,8 @@ namespace cbforest {
             if (_options.descending && !_options.includeDeleted) {
                 Document checkDoc;
                 fdb_doc* docP = (fdb_doc*)checkDoc;
-                check(fdb_iterator_get_metaonly(_iterator, &docP));
-                if (checkDoc.deleted()) {
+                if (fdb_iterator_get_metaonly(_iterator, &docP) == FDB_RESULT_SUCCESS
+                        && checkDoc.deleted()) {
                     Debug("enum: ignoring deleted doc");
                     ignoreDeleted = true;
                 }


### PR DESCRIPTION
Based on the backtrace in couchbase/couchbase-lite-java-core#971, it
appears that the fdb_iterator_get_metaonly() call added as part of the
descending-view-query workaround may return FDB_STATUS_ITERATOR_FAIL.
I think this can happen if there are no rows returned in the iteration
at all -- it's the same reason the pre-existing call to
fdb_iterator_get_metaonly in the getDoc() method below checks for that
error.
So I've changed the workaround code to ignore error returns.

Fixes couchbase/couchbase-lite-java-core#971 ... I think