### PR TITLE
Fixed Android 784 - Emitting null with the ForestDB engine causes seg…

### DIFF
--- a/Java/src/com/couchbase/cbforest/Indexer.java
+++ b/Java/src/com/couchbase/cbforest/Indexer.java
@@ -30,7 +30,7 @@ public class Indexer {
         // initialize C4Key
         long keyHandles[] = new long[keys.length];
         for (int i = 0; i < keys.length; i++) {
-            keyHandles[i] = View.objectToKey(keys[i]);
+            keyHandles[i] = View.objectToKey(keys[i], true);
         }
 
         emit(_handle, doc._handle, viewNumber, keyHandles, values);

--- a/Java/src/com/couchbase/cbforest/View.java
+++ b/Java/src/com/couchbase/cbforest/View.java
@@ -63,8 +63,8 @@ public class View {
                 descending,
                 inclusiveStart,
                 inclusiveEnd,
-                objectToKey(startKey),
-                objectToKey(endKey),
+                objectToKey(startKey, false),
+                objectToKey(endKey, false),
                 startKeyDocID,
                 endKeyDocID));
     }
@@ -80,7 +80,7 @@ public class View {
         long keyHandles[] = new long[keys.length];
         int i = 0;
         for (Object key : keys) {
-            keyHandles[i++] = objectToKey(key);
+            keyHandles[i++] = objectToKey(key, true);
         }
         return new QueryIterator(query(_handle, skip, limit, descending,
                                        inclusiveStart, inclusiveEnd, keyHandles));
@@ -113,12 +113,20 @@ public class View {
 
     //////// KEY:
 
-    // Key generation:
-
-    static long objectToKey(Object o) {
-        if (o == null) {
+    /**
+     * Key generation:
+     *
+     * @param o
+     * @param bNullKey if true, create null-key if o is null,
+     *                 otherwise, return 0 which indicates no-key
+     * @return address to key instance in native layer
+     */
+    static long objectToKey(Object o, boolean bNullKey) {
+        if (o == null && !bNullKey) {
+            // 0 -> noKey
             return 0;
         } else {
+            // o == null -> NullKey
             long key = newKey();
             try {
                 keyAdd(key, o);


### PR DESCRIPTION
…fault

Issue: https://github.com/couchbase/couchbase-lite-android/issues/784

Solution:
- In case of emit and query by key, it requires NullKey instance for null.
- In case of not set key, it requires 0 (NULL) for null.

Unit Test:
- https://github.com/couchbase/couchbase-lite-android/pull/787