### PR TITLE
Prevent closing a C4View while its index is enumerating or updating

### DIFF
--- a/C/c4Base.h
+++ b/C/c4Base.h
@@ -92,6 +92,7 @@ enum {
     kC4ErrorInternalException = 1,      // CBForest threw an unexpected C++ exception
     kC4ErrorNotInTransaction,           // Function must be called while in a transaction
     kC4ErrorTransactionNotClosed,       // Database can't be closed while a transaction is open
+    kC4ErrorIndexBusy,                  // View can't be closed while index is enumerating
 
     // These come from CBForest (error.hh)
     kC4ErrorBadRevisionID = -1000,


### PR DESCRIPTION
It will return new error kC4ErrorIndexBusy.