### PR TITLE
Fixed #78 - C4Error: variables of struct is not initialized with 0 on…

### DIFF
--- a/Java/jni/native_document.cc
+++ b/Java/jni/native_document.cc
@@ -213,7 +213,7 @@ JNIEXPORT jboolean JNICALL Java_com_couchbase_cbforest_Document_selectNextLeaf
     auto doc = (C4Document*)docHandle;
     C4Error error;
     bool ok = c4doc_selectNextLeafRevision(doc, includeDeleted, withBody, &error);
-    if (ok || error.domain == HTTPDomain)  // 404 or 410 don't trigger exceptions
+    if (ok || error.code == 0 || error.domain == HTTPDomain)  // 404 or 410 don't trigger exceptions
         updateSelection(env, self, doc, withBody);
     else
         throwError(env, error);


### PR DESCRIPTION
… Android platform

- Instead of initializing C4Error, check C4Error.error value to identify if error or not. Suggested by @snej https://github.com/couchbaselabs/cbforest/issues/78#issuecomment-207147268