### PR TITLE
Fixed #81 - Crash in ForestDB (filemgr_is_fully_resident)

### DIFF
--- a/CBForest/Database.cc
+++ b/CBForest/Database.cc
@@ -217,12 +217,6 @@ namespace cbforest {
 
 
     void Database::close() {
-        if (!isReadOnly()) {
-            // Work around data loss from bug MB-18753: recently-deleted docs still stored in
-            // the WAL may be restored to undeleted state during WAL scan on database open.
-            // Flushing the WAL will prevent this. --jpa 3/2016
-            check(fdb_commit(_fileHandle, FDB_COMMIT_MANUAL_WAL_FLUSH));
-        }
         check(::fdb_close(_fileHandle));
         // FYI: fdb_close will automatically close _handle as well.
         _fileHandle = NULL;


### PR DESCRIPTION
Crash occurs in workaround, Removed the workaround codes as https://issues.couchbase.com/browse/MB-18753 is already merged into stable branch of forestdb repo (by @hisundar).