### PR TITLE
Use HTTPS protocol for all git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/couchbaselabs/forestdb.git
 [submodule "vendor/sqlite3-unicodesn"]
 	path = vendor/sqlite3-unicodesn
-	url = git://github.com/snej/sqlite3-unicodesn.git
+	url = https://github.com/snej/sqlite3-unicodesn.git
 [submodule "vendor/openssl"]
 	path = vendor/openssl
 	url = https://github.com/couchbaselabs/couchbase-lite-libcrypto


### PR DESCRIPTION
Since many corporate firewalls block the git:// protocol port, HTTPS seems to be a better choice for git submodules.