### PR TITLE
For Android, C4DB_THREADSAFE from compiler option, so this cause  com…

### DIFF
--- a/CBForest/CBForest-Prefix.pch
+++ b/CBForest/CBForest-Prefix.pch
@@ -22,4 +22,6 @@
 #define CBFOREST_ENCRYPTION
 
 // Enable thread safety of C API:
+#ifndef C4DB_THREADSAFE
 #define C4DB_THREADSAFE 0
+#endif


### PR DESCRIPTION
…piler warning.