### PR TITLE
Fixed another scenario of FDB_RESULT_HANDLE_BUSY error.

### DIFF
--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -342,6 +342,7 @@ bool c4doc_hasRevisionBody(C4Document* doc) {
         if (!idoc->revisionsLoaded()) {
             Warn("c4doc_hasRevisionBody called on doc loaded without kC4IncludeBodies");
         }
+        WITH_LOCK(idoc->_db);
         return idoc->_selectedRev && idoc->_selectedRev->isBodyAvailable();
     } catchError(NULL);
     return false;

--- a/CBForest/LogInternal.hh
+++ b/CBForest/LogInternal.hh
@@ -31,6 +31,15 @@ void _Log(logLevel, const char *message, ...);
     #define Log(MESSAGE, ...)        LogAt(kInfo,    MESSAGE, __VA_ARGS__)
     #define Warn(MESSAGE, ...)       LogAt(kWarning, MESSAGE, __VA_ARGS__)
     #define WarnError(MESSAGE, ...)  LogAt(kError,   MESSAGE, __VA_ARGS__)
+#elif __ANDROID__
+    #include <android/log.h>
+    #define  LOG_TAG "cbforest"
+    #define LogAt(LEVEL, ...) \
+                if (LogLevel <= LEVEL) _Log(LEVEL, MESSAGE, __VA_ARGS__);
+    #define Debug(...)      __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
+    #define Log(...)        __android_log_print(ANDROID_LOG_INFO,  LOG_TAG, __VA_ARGS__)
+    #define Warn( ...)      __android_log_print(ANDROID_LOG_WARN,  LOG_TAG, __VA_ARGS__)
+    #define WarnError(...)  __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
 #else
     #define LogAt(LEVEL, MESSAGE...) \
                 ({if (__builtin_expect(LogLevel <= LEVEL, false)) _Log(LEVEL, MESSAGE);})


### PR DESCRIPTION
Forest FC when save record (Note: ForestDB error code = -39)
https://github.com/couchbase/couchbase-lite-android/issues/909

- Fixed scenario: Thread1: push replicator, Thread2: keep inserting.
- This PR along with native logging code for Android.