### PR TITLE
Fixed #96 - Compilation warning with 64bit Android - type mismatch be…

### DIFF
--- a/CBForest/KeyStore.cc
+++ b/CBForest/KeyStore.cc
@@ -144,7 +144,7 @@ namespace cbforest {
         doc.bodylen = body.size;
 
         check(fdb_set(_handle, &doc));
-        Log("DB %p: added %s --> %s (meta %s) (seq %llu)\n",
+        Log("DB %p: added %s --> %s (meta %s) (seq %" _F64 ")\n",
             _handle, key.hexCString(), body.hexCString(), meta.hexCString(), doc.seqnum);
         return doc.seqnum;
     }

--- a/CBForest/KeyStore.hh
+++ b/CBForest/KeyStore.hh
@@ -13,6 +13,17 @@
 #include "forestdb.h"
 #include "slice.hh"
 
+// note: fdb_seqnum_t is platform dependent. see arch.h in forestdb
+#ifdef __ANDROID__
+#if defined(__arm__) || defined(__i386__) || defined(__mips32__)
+#define _F64 "llu"
+#else
+#define _F64 "lu"
+#endif
+#else
+#define _F64 "llu"
+#endif
+
 namespace cbforest {
 
     class Database;


### PR DESCRIPTION
…tween unsigned long and unsigned long long

- Accord to forestdb team `fdb_seqnum_t` (`uint64_t`) is dependent. They recommends to use macro to print it.
- I wonder non-Android platforms is 64bit, but they don't have this warning. It might need to change to `%lu`.