### PR TITLE
Set GENERATE_MASTER_OBJECT_FILE=NO

### DIFF
--- a/xcconfigs/CBForest static.xcconfig
+++ b/xcconfigs/CBForest static.xcconfig
@@ -10,7 +10,7 @@
 DSTROOT                      = /tmp/CBForest_iOS.dst
 GCC_PRECOMPILE_PREFIX_HEADER = YES
 GCC_PREFIX_HEADER            = CBForest/CBForest-Prefix.pch
-GENERATE_MASTER_OBJECT_FILE  = YES
+GENERATE_MASTER_OBJECT_FILE  = NO
 HEADER_SEARCH_PATHS          = $(inherited) $(SRCROOT)/vendor/forestdb/include/**
 PRODUCT_NAME                 = CBForest
 SKIP_INSTALL                 = YES

--- a/xcconfigs/CBForest static.xcconfig
+++ b/xcconfigs/CBForest static.xcconfig
@@ -10,7 +10,6 @@
 DSTROOT                      = /tmp/CBForest_iOS.dst
 GCC_PRECOMPILE_PREFIX_HEADER = YES
 GCC_PREFIX_HEADER            = CBForest/CBForest-Prefix.pch
-GENERATE_MASTER_OBJECT_FILE  = NO
 HEADER_SEARCH_PATHS          = $(inherited) $(SRCROOT)/vendor/forestdb/include/**
 PRODUCT_NAME                 = CBForest
 SKIP_INSTALL                 = YES


### PR DESCRIPTION
Set GENERATE_MASTER_OBJECT_FILE=NO to fix unable to open object file warning messages when the library is used.

Reference: https://github.com/couchbase/couchbase-lite-ios/issues/1376.