### PR TITLE
Fixed #100 - Android: LogLevel does not effect for Android.

### DIFF
--- a/CBForest/Database.cc
+++ b/CBForest/Database.cc
@@ -26,14 +26,21 @@
 #include <unordered_map>
 #ifdef _MSC_VER
 #include "asprintf.h"
+#elif __ANDROID__
+#include <android/log.h>
 #endif
 
 
 namespace cbforest {
 
     static void defaultLogCallback(logLevel level, const char *message) {
-        static const char* kLevelNames[4] = {"debug", "info", "WARNING", "ERROR"};
+#ifdef __ANDROID__
+        static const int kLevels[4] = {ANDROID_LOG_DEBUG, ANDROID_LOG_INFO, ANDROID_LOG_WARN, ANDROID_LOG_ERROR};
+        __android_log_write(kLevels[level], "CBForest", message);
+#else
+        static const char *kLevelNames[4] = {"debug", "info", "WARNING", "ERROR"};
         fprintf(stderr, "CBForest %s: %s\n", kLevelNames[level], message);
+#endif
     }
 
     logLevel LogLevel = kWarning;

--- a/CBForest/LogInternal.hh
+++ b/CBForest/LogInternal.hh
@@ -31,15 +31,6 @@ void _Log(logLevel, const char *message, ...);
     #define Log(MESSAGE, ...)        LogAt(kInfo,    MESSAGE, __VA_ARGS__)
     #define Warn(MESSAGE, ...)       LogAt(kWarning, MESSAGE, __VA_ARGS__)
     #define WarnError(MESSAGE, ...)  LogAt(kError,   MESSAGE, __VA_ARGS__)
-#elif __ANDROID__
-    #include <android/log.h>
-    #define  LOG_TAG "cbforest"
-    #define LogAt(LEVEL, ...) \
-                if (LogLevel <= LEVEL) _Log(LEVEL, MESSAGE, __VA_ARGS__);
-    #define Debug(...)      __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
-    #define Log(...)        __android_log_print(ANDROID_LOG_INFO,  LOG_TAG, __VA_ARGS__)
-    #define Warn( ...)      __android_log_print(ANDROID_LOG_WARN,  LOG_TAG, __VA_ARGS__)
-    #define WarnError(...)  __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
 #else
     #define LogAt(LEVEL, MESSAGE...) \
                 ({if (__builtin_expect(LogLevel <= LEVEL, false)) _Log(LEVEL, MESSAGE);})


### PR DESCRIPTION
- Issue: LogLevel is not checked.
- Solution: just using `__android_log_write()` which is logging method for android native library, instead of `fprintf()`.