### PR TITLE
Fix tvOS build warnings

### DIFF
--- a/xcconfigs/Project.xcconfig
+++ b/xcconfigs/Project.xcconfig
@@ -7,6 +7,7 @@
 
 IPHONEOS_DEPLOYMENT_TARGET                         = 7.0
 MACOSX_DEPLOYMENT_TARGET                           = 10.8
+TVOS_DEPLOYMENT_TARGET                             = 9.0
 ONLY_ACTIVE_ARCH                                   = NO
 SKIP_INSTALL                                       = YES
 SUPPORTED_PLATFORMS                                = macosx iphoneos iphonesimulator appletvos appletvsimulator


### PR DESCRIPTION
Set tvOS deployment target to 9.0.

Reference: https://github.com/couchbase/couchbase-lite-ios/issues/1387