### PR TITLE
Fixed: ForestDB: Query.setLimit() could cause crashes.

### DIFF
--- a/Java/src/com/couchbase/cbforest/DocumentIterator.java
+++ b/Java/src/com/couchbase/cbforest/DocumentIterator.java
@@ -58,7 +58,20 @@ public class DocumentIterator {
         return next() ? getDocument() : null;
     }
 
-    protected void finalize()       { if (_handle != 0) free(_handle); }
+    public void close() {
+        if (_handle != 0) {
+            free(_handle);
+            _handle = 0;
+        }
+    }
+
+    protected void finalize() throws Throwable {
+        try {
+            if (_handle != 0) free(_handle);
+        } finally {
+            super.finalize();
+        }
+    }
 
     private void getCurrentInfo() {
         if (!_hasCurrentInfo) {


### PR DESCRIPTION
Ticket: https://github.com/couchbase/couchbase-lite-java-core/issues/1441

Description: In case forestdb store is already closed when closing forestdb iterator, fdb_iterator_close() causes crash. This scenario could be happen because DocumentIterator.free(handle) is called from finalize(). To avoid this scenario, DocumentIterator should provide `public void close()` method to allow Java codes close DocumentIterator explicitly.