### PR TITLE
Fixed crash in c4view_open, and other potential destructor-triggered crashes

### DIFF
--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -255,7 +255,7 @@ C4Database* c4db_open(C4Slice path,
     auto config = c4DbConfig(flags, encryptionKey);
     try {
         try {
-            return new c4Database(pathStr, config);
+            return (new c4Database(pathStr, config))->retain();
         } catch (cbforest::error error) {
             if (error.status == FDB_RESULT_INVALID_COMPACTION_MODE
                         && config.compaction_mode == FDB_COMPACTION_AUTO) {
@@ -263,7 +263,7 @@ C4Database* c4db_open(C4Slice path,
                 // Opening them with auto-compact causes this error. Upgrade such a database by
                 // switching its compaction mode:
                 config.compaction_mode = FDB_COMPACTION_MANUAL;
-                auto db = new c4Database(pathStr, config);
+                auto db = (new c4Database(pathStr, config))->retain();
                 db->setCompactionMode(FDB_COMPACTION_AUTO);
                 return db;
             } else {

--- a/C/c4DocEnumerator.cc
+++ b/C/c4DocEnumerator.cc
@@ -39,7 +39,7 @@ struct C4DocEnumerator: c4Internal::InstanceCounted {
                     sequence start,
                     sequence end,
                     const C4EnumeratorOptions &options)
-    :_database(database->retain()),
+    :_database(database),
      _e(*database, start, end, allDocOptions(options)),
      _options(options)
     { }
@@ -48,7 +48,7 @@ struct C4DocEnumerator: c4Internal::InstanceCounted {
                     C4Slice startDocID,
                     C4Slice endDocID,
                     const C4EnumeratorOptions &options)
-    :_database(database->retain()),
+    :_database(database),
      _e(*database, startDocID, endDocID, allDocOptions(options)),
      _options(options)
     { }
@@ -56,14 +56,10 @@ struct C4DocEnumerator: c4Internal::InstanceCounted {
     C4DocEnumerator(C4Database *database,
                     std::vector<std::string>docIDs,
                     const C4EnumeratorOptions &options)
-    :_database(database->retain()),
+    :_database(database),
      _e(*database, docIDs, allDocOptions(options)),
      _options(options)
     { }
-
-    ~C4DocEnumerator() {
-        _database->release();
-    }
 
     void close() {
         _e.close();
@@ -129,7 +125,7 @@ private:
             && (!_filter || _filter(_e.doc(), _docFlags, docType));
     }
 
-    C4Database *_database;
+    Retained<C4Database> _database;
     DocEnumerator _e;
     C4EnumeratorOptions _options;
     EnumFilter _filter;

--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -40,7 +40,7 @@ static const uint32_t kDefaultMaxRevTreeDepth = 20;
 
 
 struct C4DocumentInternal : public C4Document, c4Internal::InstanceCounted {
-    C4Database* _db;
+    Retained<C4Database> _db;
     VersionedDocument _versionedDoc;
     const Revision *_selectedRev;
     alloc_slice _revIDBuf;
@@ -48,7 +48,7 @@ struct C4DocumentInternal : public C4Document, c4Internal::InstanceCounted {
     alloc_slice _loadedBody;
 
     C4DocumentInternal(C4Database* database, C4Slice docID)
-    :_db(database->retain()),
+    :_db(database),
      _versionedDoc(*_db, docID),
      _selectedRev(NULL)
     {
@@ -56,15 +56,11 @@ struct C4DocumentInternal : public C4Document, c4Internal::InstanceCounted {
     }
 
     C4DocumentInternal(C4Database *database, Document &&doc)
-    :_db(database->retain()),
+    :_db(database),
     _versionedDoc(*_db, std::move(doc)),
     _selectedRev(NULL)
     {
         init();
-    }
-
-    ~C4DocumentInternal() {
-        _db->release();
     }
 
     void init() {

--- a/C/c4ExpiryEnumerator.cc
+++ b/C/c4ExpiryEnumerator.cc
@@ -23,16 +23,12 @@ struct C4ExpiryEnumerator
 {
 public:
     C4ExpiryEnumerator(C4Database *database) :
-    _db(database->retain()),
+    _db(database),
     _e(_db->getKeyStore("expiry"), slice::null, slice::null),
     _reader(slice::null)
     {
         _endTimestamp = time(NULL);
         reset();
-    }
-
-    ~C4ExpiryEnumerator() {
-        _db->release();
     }
 
     bool next() {
@@ -81,7 +77,7 @@ public:
     }
     
 private:
-    C4Database *_db;
+    Retained<C4Database> _db;
     DocEnumerator _e;
     alloc_slice _current;
     CollatableReader _reader;

--- a/CBForest Tests/GeoIndex_Test.mm
+++ b/CBForest Tests/GeoIndex_Test.mm
@@ -102,6 +102,7 @@ static double randomLon()   {return random() / (double)INT_MAX * 360.0 - 180.0;}
         t.set(slice(docID), body);
         NSLog(@"Added %s --> (%+08.4f, %+09.4f)", docID, lat0, lon0);
     }
+    t.commit();
 }
 
 - (void) indexIt {

--- a/CBForest Tests/Index_Test.mm
+++ b/CBForest Tests/Index_Test.mm
@@ -131,6 +131,7 @@ static boolBlock scopedEnumerate() {
         IndexWriter writer(index, trans);
         for (NSString* docID in docs)
             [self updateDoc: docID body: docs[docID] writer: writer];
+        trans.commit();
     }
 
     NSLog(@"--- First query");
@@ -142,6 +143,7 @@ static boolBlock scopedEnumerate() {
         NSLog(@"--- Updating OR");
         [self updateDoc: @"OR" body: @[@"Oregon", @"Portland", @"Walla Walla", @"Salem"]
                  writer: writer];
+        trans.commit();
     }
     XCTAssertEqual([self doQuery], 9);
 
@@ -150,6 +152,7 @@ static boolBlock scopedEnumerate() {
         Transaction trans(database);
         IndexWriter writer(index, trans);
         [self updateDoc: @"CA" body: @[] writer: writer];
+        trans.commit();
     }
     XCTAssertEqual([self doQuery], 6);
 
@@ -214,6 +217,7 @@ static boolBlock scopedEnumerate() {
         bool changed = writer.update(slice("doc1"), 1, keys, values, _rowCount);
         Assert(changed);
         AssertEq(_rowCount, 2u);
+        trans.commit();
     }
     NSLog(@"--- First query");
     XCTAssertEqual([self doQuery], 2);
@@ -232,6 +236,7 @@ static boolBlock scopedEnumerate() {
         bool changed = writer.update(slice("doc1"), 2, keys, values, _rowCount);
         Assert(changed);
         AssertEq(_rowCount, 3u);
+        trans.commit();
     }
     NSLog(@"--- Second query");
     XCTAssertEqual([self doQuery], 3);

--- a/CBForest Tests/VersionedDocument_Tests.mm
+++ b/CBForest Tests/VersionedDocument_Tests.mm
@@ -149,6 +149,7 @@ static revidBuffer stringToRev(NSString* str) {
         AssertEq(v.docType(), slice("moose"));
         Transaction t(db);
         v.save(t);
+        t.commit();
     }
     {
         VersionedDocument v(*db, @"foo");

--- a/CBForest/Database.cc
+++ b/CBForest/Database.cc
@@ -46,7 +46,7 @@ namespace cbforest {
     logLevel LogLevel = kWarning;
     void (*LogCallback)(logLevel, const char *message) = &defaultLogCallback;
 
-    void _Log(logLevel level, const char *message, ...) {
+    void _Log(logLevel level, const char *message, ...) noexcept {
         if (LogLevel <= level && LogCallback != NULL) {
             va_list args;
             va_start(args, message);
@@ -257,7 +257,7 @@ namespace cbforest {
 
     void Database::deleteDatabase() {
         if (isOpen()) {
-            Transaction t(this, false);
+            Transaction t(this, false); // fake transaction -- just used for the mutex
             close();
             deleteDatabase(_file->_path, _config);
         } else {
@@ -277,7 +277,7 @@ namespace cbforest {
 
 #pragma mark - TRANSACTION:
 
-    void Database::beginTransaction(Transaction* t) {
+    void Database::beginTransaction(Transaction* t, bool active) {
         CBFAssert(!_inTransaction);
         if (!isOpen())
             error::_throw(FDB_RESULT_INVALID_HANDLE);
@@ -285,67 +285,68 @@ namespace cbforest {
         while (_file->_transaction != NULL)
             _file->_transactionCond.wait(lock);
 
-        if (t->state() >= Transaction::kCommit) {
+        _file->_transaction = t;
+        _inTransaction = true;
+
+        if (active) {
             Log("Database: beginTransaction");
             check(fdb_begin_transaction(_fileHandle, FDB_ISOLATION_READ_COMMITTED));
         }
-        _file->_transaction = t;
-        _inTransaction = true;
+    }
+
+    void Database::commitTransaction(Transaction* t) {
+        Log("Database: commit transaction");
+        CBFAssert(_file->_transaction == t);
+        check(fdb_end_transaction(_fileHandle, FDB_COMMIT_NORMAL));
+    }
+
+    void Database::abortTransaction(Transaction* t) {
+        Log("Database: abort transaction");
+        CBFAssert(_file->_transaction == t);
+        fdb_abort_transaction(_fileHandle);
     }
 
     void Database::endTransaction(Transaction* t) {
-        fdb_status status = FDB_RESULT_SUCCESS;
-        switch (t->state()) {
-            case Transaction::kCommit:
-                Log("Database: commit transaction");
-                status = fdb_end_transaction(_fileHandle, FDB_COMMIT_NORMAL);
-                break;
-            case Transaction::kCommitManualWALFlush:
-                Log("Database: commit transaction with WAL flush");
-                status = fdb_end_transaction(_fileHandle, FDB_COMMIT_MANUAL_WAL_FLUSH);
-                break;
-            case Transaction::kAbort:
-                Log("Database: abort transaction");
-                (void)fdb_abort_transaction(_fileHandle);
-                break;
-            case Transaction::kNoOp:
-                Log("Database: end noop transaction");
-                break;
-        }
-
         std::unique_lock<std::mutex> lock(_file->_transactionMutex);
         CBFAssert(_file->_transaction == t);
         _file->_transaction = NULL;
         _file->_transactionCond.notify_one();
         _inTransaction = false;
-
-        check(status);
     }
 
 
     Transaction::Transaction(Database* db)
+    :Transaction(db, true)
+    { }
+
+    Transaction::Transaction(Database* db, bool active)
     :KeyStoreWriter(*db),
      _db(*db),
-     _state(kCommit)
+     _active(false)
     {
-        _db.beginTransaction(this);
+        _db.beginTransaction(this, active);
+        _active = active;
     }
 
-    Transaction::Transaction(Database* db, bool begin)
-    :KeyStoreWriter(*db),
-     _db(*db),
-     _state(begin ? kCommit : kNoOp)
-    {
-        _db.beginTransaction(this);
+    void Transaction::commit() {
+        CBFAssert(_active);
+        _active = false;
+        _db.commitTransaction(this);
     }
 
-    void Transaction::check(fdb_status status) {
-        if (expected(status != FDB_RESULT_SUCCESS, false)) {
-            _state = kAbort;
-            cbforest::check(status); // throw exception
+    void Transaction::abort() {
+        CBFAssert(_active);
+        _active = false;
+        _db.abortTransaction(this);
+    }
+
+    Transaction::~Transaction() {
+        if (_active) {
+            Log("Database: Transaction exiting scope without explicit commit or abort");
+            _db.abortTransaction(this);
         }
+        _db.endTransaction(this);
     }
-
 
     bool Transaction::del(slice key) {
         if (!KeyStoreWriter::del(key))

--- a/CBForest/LogInternal.hh
+++ b/CBForest/LogInternal.hh
@@ -21,7 +21,7 @@
 
 namespace cbforest {
 
-void _Log(logLevel, const char *message, ...);
+void _Log(logLevel, const char *message, ...) noexcept;
 
 #ifdef _MSC_VER
     // Apparently vararg macro syntax is slightly different in MSVC than in Clang/GCC

--- a/CBForest/MapReduceIndex.cc
+++ b/CBForest/MapReduceIndex.cc
@@ -362,6 +362,7 @@ namespace cbforest {
                 index->_lastSequenceIndexed = std::max(index->_lastSequenceIndexed,
                                                        finalSequence);
                 index->saveState(*_transaction);
+                _transaction->commit();
             } else {
                 _transaction->abort();
             }
@@ -412,9 +413,14 @@ namespace cbforest {
     }
 
 
+    void MapReduceIndexer::finished(sequence seq) {
+        for (auto writer = _writers.begin(); writer != _writers.end(); ++writer) {
+            (*writer)->finish(seq);
+        }
+    }
+
     MapReduceIndexer::~MapReduceIndexer() {
         for (auto writer = _writers.begin(); writer != _writers.end(); ++writer) {
-            (*writer)->finish(_finishedSequence);
             delete *writer;
         }
     }

--- a/CBForest/MapReduceIndex.hh
+++ b/CBForest/MapReduceIndex.hh
@@ -91,7 +91,7 @@ namespace cbforest {
     class MapReduceIndexer {
     public:
         ~MapReduceIndexer();
-
+        
         void addIndex(MapReduceIndex*);
 
         /** If set, indexing will only occur if this index needs to be updated. */
@@ -130,13 +130,12 @@ namespace cbforest {
 
         /** Call when all documents have been indexed. Pass the last sequence that was enumerated
             (usually the database's lastSequence).*/
-        void finished(sequence seq =1)       {_finishedSequence = seq;}
+        void finished(sequence seq =1);
 
     private:
         std::vector<MapReduceIndexWriter*> _writers;
         MapReduceIndex* _triggerIndex {nullptr};
         sequence _latestDbSequence {0};
-        sequence _finishedSequence {0};
         bool _allDocTypes {false};
         std::set<slice> _docTypes;
 


### PR DESCRIPTION
A bug in the RefCounted class's design was causing an assertion failure in its destructor, causing the process to abort because in C++11 it's a fatal error for a destructor to throw an exception. Fixed this and refactored two other classes so their destructors weren't doing work that could throw.

Fixes #105. 