### PR TITLE
Fixed Issue Java Core 1424 - MultiThreadsTest.testParallelViewQueries…

### DIFF
--- a/CBForest/Database.cc
+++ b/CBForest/Database.cc
@@ -278,7 +278,6 @@ namespace cbforest {
 #pragma mark - TRANSACTION:
 
     void Database::beginTransaction(Transaction* t) {
-        CBFAssert(!_inTransaction);
         if (!isOpen())
             error::_throw(FDB_RESULT_INVALID_HANDLE);
         std::unique_lock<std::mutex> lock(_file->_transactionMutex);


### PR DESCRIPTION
…WithPrefix() fails with forestdb

Description: With multiple views with same prefix, calling View.updateIndexes() from multiple threads hits Assertion in Database::beginTransaction(). But, creating another transaction from other tread is write operation. This assertion is no longer necessary.