### PR TITLE
Fixed Java Core Issue 1448 - CBForest: Assertion failed: !_inTransact…

### DIFF
--- a/CBForest/Database.cc
+++ b/CBForest/Database.cc
@@ -278,7 +278,6 @@ namespace cbforest {
 #pragma mark - TRANSACTION:
 
     void Database::beginTransaction(Transaction* t, bool active) {
-        CBFAssert(!_inTransaction);
         if (!isOpen())
             error::_throw(FDB_RESULT_INVALID_HANDLE);
         std::unique_lock<std::mutex> lock(_file->_transactionMutex);


### PR DESCRIPTION
…ion in Database::beginTransaction()

With view/query with multi-threads, currently CBL Android faces assertion failure with `!_inTransaction in Database::beginTransaction()`.

Transaction should be only one per Database. But, as Line 285 and 286 waits till `_file->_transaction` becomes `NULL`. So `CBFAssert(!_inTransaction);` at beginning of `beginTransaction()` is inappropriate.

```c++
    void Database::beginTransaction(Transaction* t, bool active) {
        CBFAssert(!_inTransaction);
        if (!isOpen())
            error::_throw(FDB_RESULT_INVALID_HANDLE);
        std::unique_lock<std::mutex> lock(_file->_transactionMutex);
        while (_file->_transaction != NULL)
            _file->_transactionCond.wait(lock);

        _file->_transaction = t;
        _inTransaction = true;

        if (active) {
            Log("Database: beginTransaction");
            check(fdb_begin_transaction(_fileHandle, FDB_ISOLATION_READ_COMMITTED));
        }
    }
```