### PR TITLE
Fixed Java Core Issue 1597 - P2P - ForestDB Error: forceInsert()

### DIFF
--- a/C/c4DocEnumerator.cc
+++ b/C/c4DocEnumerator.cc
@@ -83,6 +83,7 @@ struct C4DocEnumerator: c4Internal::InstanceCounted {
     C4Database* database() const {return _database;}
 
     bool next() {
+        WITH_LOCK(_database);
         do {
             if (!_e.next())
                 return false;


### PR DESCRIPTION
Original ticket: https://github.com/couchbase/couchbase-lite-java-core/issues/1597

Functional Test creates concurrent scenario with pull replicator inserts docs and listener handles /_all_docs REST API request. As cbforest iterator’s next() method accesses forestdb file without having mutex, beginTransaction() or endTransaction() which are called from pull replicator fails with DB Handle Busy error (-39).