### PR TITLE
Fixed xcode 8.3 build error

### DIFF
--- a/CBForest/Collatable.mm
+++ b/CBForest/Collatable.mm
@@ -15,7 +15,7 @@
 
 #import <Foundation/Foundation.h>
 #import "Collatable.hh"
-#import "error.hh"
+#import "Error.hh"
 
 
 namespace cbforest {


### PR DESCRIPTION
* WIth xcode 8.3, the error is non-portable path to file '"Error.hh"'; specified path differs in case from file name on disk [-Werror,-Wnonportable-include-path].
* Imported Error.hh instead of error.hh.